### PR TITLE
Changed regex to allow underscore and dash as leading character

### DIFF
--- a/src/main/java/flowctrl/integration/slack/validation/SlackFieldValidationUtils.java
+++ b/src/main/java/flowctrl/integration/slack/validation/SlackFieldValidationUtils.java
@@ -8,7 +8,7 @@ import flowctrl.integration.slack.exception.SlackArgumentException;
 
 public abstract class SlackFieldValidationUtils {
 
-	private static final String CHANNEL_NAME_REGEX = "^[a-z0-9]{1}[a-z0-9-_]{0,20}$";
+	private static final String CHANNEL_NAME_REGEX = "^[a-z0-9-_]{1}[a-z0-9-_]{0,20}$";
 	private static final Set<String> RESERVED_WORDS = new HashSet<String>(Arrays.asList(
 		"archive", "archived", "archives", "all", "channel",
 		"channels", "create", "delete", "deleted-channel", "edit",


### PR DESCRIPTION
Channel names are allowed to start with an underscore and dash.