### PR TITLE
Return channel ID resulted from im.open call

### DIFF
--- a/src/main/java/flowctrl/integration/slack/webapi/SlackWebApiClient.java
+++ b/src/main/java/flowctrl/integration/slack/webapi/SlackWebApiClient.java
@@ -115,10 +115,10 @@ public interface SlackWebApiClient {
 	History getDirectMessageChannelHistory(String channel, String latest, String oldest, boolean inclusive, int count, boolean unreads);
 	List<DirectMessageChannel> getDirectMessageChannelList();
 	boolean markDirectMessageChannel(String channel, String ts);
-	boolean openDirectMessageChannel(String user);
-	
+	String openDirectMessageChannel(String user);
+
 	// mpim (multiparty direct message channel)
-	
+
 	boolean closeMultipartyDirectMessageChannel(String channel);
 	History getMultipartyDirectMessageChannelHistory(String channel);
 	History getMultipartyDirectMessageChannelHistory(String channel, int count);

--- a/src/main/java/flowctrl/integration/slack/webapi/SlackWebApiClientImpl.java
+++ b/src/main/java/flowctrl/integration/slack/webapi/SlackWebApiClientImpl.java
@@ -584,8 +584,11 @@ public class SlackWebApiClientImpl implements SlackWebApiClient {
 	}
 
 	@Override
-	public boolean openDirectMessageChannel(String user) {
-		return isOk(new ImOpenMethod(user));
+	public String openDirectMessageChannel(String user) {
+        ImOpenMethod method = new ImOpenMethod(user) ;
+        JsonNode retNode = call(method) ;
+
+		return retNode.findPath("id").asText();
 	}
 
 	// mpim (multiparty direct message channel)


### PR DESCRIPTION
Web API method im.open, in a successful call scenario, returns the
newly openned channel ID. This channel ID is required to call
chat.postMessage successfully. The method implemented in
SlackWebApiClientImpl.openDirectMessageChannel(String) should return
this ID.

This commit provides the necessary code change in the interface and
the implementation class. Fix for issue #4 