### PR TITLE
Attachment: Fix setColor refusing valid hex color

### DIFF
--- a/src/main/java/flowctrl/integration/slack/type/Attachment.java
+++ b/src/main/java/flowctrl/integration/slack/type/Attachment.java
@@ -58,7 +58,7 @@ public class Attachment {
 	public void setColor(String color) {
 		if (color != null) {
 			if (color.charAt(0) == '#') {
-				if (color.substring(1).matches(HEX_REGEX)) {
+				if (!color.substring(1).matches(HEX_REGEX)) {
 					throw new SlackArgumentException("invalid hex color");
 				}
 			} else if (!color.matches(PREDEFINED_COLOR_REGEX)) {


### PR DESCRIPTION
Seems the logic is inverted here, causing it to throw an exception when any valid color is passed to `Attachment#setColor`.